### PR TITLE
Uninstall gpsami binary

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,9 @@ install-exec-local:
 	$(MKDIR_P) $(DESTDIR)$(bindir)
 	$(INSTALL) -c -m 755 target/@CARGO_TARGET_DIR@/gpsami $(DESTDIR)$(bindir)
 
+uninstall-local:
+	rm $(DESTDIR)$(bindir)/gpsami
+
 DISTCLEANFILES =                                \
 	$(desktop_files)                        \
 	$(null)


### PR DESCRIPTION
This adds an `uninstall-local` task which removes the `gpsami` binary
from `$bindir`. This is done manually via `rm`.

There might be a better way of telling Automake about this executable.
